### PR TITLE
Remove some usages of JsArray and JavaScriptObject

### DIFF
--- a/gwt-dom-gwt2-tests/src/test/java/org/gwtproject/dom/client/NodeTest.java
+++ b/gwt-dom-gwt2-tests/src/test/java/org/gwtproject/dom/client/NodeTest.java
@@ -19,7 +19,6 @@ import com.google.gwt.junit.DoNotRunWith;
 import com.google.gwt.junit.Platform;
 import com.google.gwt.junit.client.GWTTestCase;
 import java.util.Locale;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /** Tests the {@link Node} class. */
 public class NodeTest extends GWTTestCase {
@@ -296,7 +295,7 @@ public class NodeTest extends GWTTestCase {
   public void testIsAndAs() {
     assertTrue(Node.is(Document.get()));
 
-    JavaScriptObject text = Document.get().createTextNode("foo");
+    Object text = Document.get().createTextNode("foo");
     assertTrue(Node.is(text));
 
     // Node.is(null) is allowed and should return false.

--- a/gwt-dom-j2cl-tests/src/test/java/org/gwtproject/dom/client/NodeTest.java
+++ b/gwt-dom-j2cl-tests/src/test/java/org/gwtproject/dom/client/NodeTest.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import static junit.framework.TestCase.*;
 
 import java.util.Locale;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.junit.Test;
 
 /** Tests the {@link Node} class. */
@@ -280,7 +279,7 @@ public class NodeTest {
   public void testIsAndAs() {
     assertTrue(Node.is(Document.get()));
 
-    JavaScriptObject text = Document.get().createTextNode("foo");
+    Object text = Document.get().createTextNode("foo");
     assertTrue(Node.is(text));
 
     // Node.is(null) is allowed and should return false.

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/AnchorElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/AnchorElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.gwtproject.safehtml.shared.SafeUri;
 import org.gwtproject.safehtml.shared.annotations.IsSafeUri;
 
@@ -49,14 +48,14 @@ public class AnchorElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/AreaElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/AreaElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Client-side image map area definition.
@@ -47,14 +46,14 @@ public class AreaElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/BRElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/BRElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Force a line break.
@@ -46,14 +45,14 @@ public class BRElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/BaseElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/BaseElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Document base URI.
@@ -47,14 +46,14 @@ public class BaseElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/BodyElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/BodyElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * The HTML document body. This element is always present in the DOM API, even if the tags are not
@@ -47,14 +46,14 @@ public class BodyElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/ButtonElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/ButtonElement.java
@@ -21,7 +21,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Push button.
@@ -49,14 +48,14 @@ public class ButtonElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/DListElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/DListElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Definition list.
@@ -46,14 +45,14 @@ public class DListElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/DivElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/DivElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Generic block container.
@@ -46,14 +45,14 @@ public class DivElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/Element.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/Element.java
@@ -83,14 +83,14 @@ public class Element extends Node {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to an {@link Element}. A
+   * Determines whether the given object can be cast to an {@link Element}. A
    * <code>null</code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Node.is(o)) {
       return is((Node) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/EventTarget.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/EventTarget.java
@@ -23,7 +23,7 @@ import org.gwtproject.core.client.JavaScriptObject;
  * Represents the target of a JavaScript event.
  *
  * <p>This type is returned from methods such as {@link NativeEvent#getEventTarget()}, and must
- * usually be cast to another type using methods such as {@link Element#is(JavaScriptObject)} and
+ * usually be cast to another type using methods such as {@link Element#is(Object)} and
  * {@link Element#as(JavaScriptObject)}.
  *
  * <p>This class intentionally does <em>not</em> specify the methods from the DOM IDL

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/FieldSetElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/FieldSetElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Organizes form controls into logical groups.
@@ -48,14 +47,14 @@ public class FieldSetElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/FormElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/FormElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.gwtproject.safehtml.shared.SafeUri;
 import org.gwtproject.safehtml.shared.annotations.IsSafeUri;
 
@@ -50,14 +49,14 @@ public class FormElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/FrameElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/FrameElement.java
@@ -21,7 +21,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.gwtproject.safehtml.shared.SafeUri;
 import org.gwtproject.safehtml.shared.annotations.IsSafeUri;
 import org.gwtproject.safehtml.shared.annotations.IsTrustedResourceUri;
@@ -53,14 +52,14 @@ public class FrameElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/FrameSetElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/FrameSetElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Create a grid of frames.
@@ -48,14 +47,14 @@ public class FrameSetElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/HRElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/HRElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Create a horizontal rule.
@@ -46,14 +45,14 @@ public class HRElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/HeadElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/HeadElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Document head information.
@@ -46,14 +45,14 @@ public class HeadElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/HeadingElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/HeadingElement.java
@@ -19,7 +19,6 @@ import java.util.Locale;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * For the H1 to H6 elements.
@@ -68,14 +67,14 @@ public class HeadingElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/IFrameElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/IFrameElement.java
@@ -20,7 +20,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.gwtproject.safehtml.shared.SafeUri;
 import org.gwtproject.safehtml.shared.annotations.IsSafeUri;
 
@@ -50,14 +49,14 @@ public class IFrameElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/ImageElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/ImageElement.java
@@ -20,7 +20,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Embedded image.
@@ -48,14 +47,14 @@ public class ImageElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/InputElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/InputElement.java
@@ -21,7 +21,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Form control.
@@ -53,14 +52,14 @@ public class InputElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/LIElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/LIElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * List item.
@@ -46,14 +45,14 @@ public class LIElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/LabelElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/LabelElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Form field label text.
@@ -47,14 +46,14 @@ public class LabelElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/LegendElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/LegendElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Provides a caption for a FIELDSET grouping.
@@ -47,14 +46,14 @@ public class LegendElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/LinkElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/LinkElement.java
@@ -21,7 +21,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.gwtproject.safehtml.shared.annotations.IsTrustedResourceUri;
 
 /**
@@ -51,14 +50,14 @@ public class LinkElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/MapElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/MapElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Client-side image map.
@@ -47,14 +46,14 @@ public class MapElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/MetaElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/MetaElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * This contains generic meta-information about the document.
@@ -47,14 +46,14 @@ public class MetaElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/ModElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/ModElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.gwtproject.safehtml.shared.SafeUri;
 import org.gwtproject.safehtml.shared.annotations.IsSafeUri;
 
@@ -52,14 +51,14 @@ public class ModElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/Node.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/Node.java
@@ -45,19 +45,19 @@ public class Node extends JavaScriptObject {
   public static short DOCUMENT_NODE;
 
   /**
-   * Assert that the given {@link JavaScriptObject} is a DOM node and automatically typecast it.
+   * Assert that the given object is a DOM node and automatically typecast it.
    *
    * @param o the object to assert is a Node
    * @return the object, cast to a Node
    */
   @JsOverlay
-  public static Node as(JavaScriptObject o) {
+  public static Node as(Object o) {
     assert is(o);
     return (Node) o;
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} is a DOM node. A <code>null</code> object
+   * Determines whether the given object is a DOM node. A <code>null</code> object
    * will cause this method to return <code>false</code>. The try catch is needed for the firefox
    * permission error: "Permission denied to access property 'nodeType'"
    *
@@ -65,7 +65,7 @@ public class Node extends JavaScriptObject {
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     try {
       return Js.isTruthy(o) && Js.isTruthy(Js.asPropertyMap(o).get("nodeType"));
     } catch (Exception e) {

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/OListElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/OListElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Ordered list.
@@ -46,14 +45,14 @@ public class OListElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/ObjectElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/ObjectElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.gwtproject.safehtml.shared.SafeUri;
 import org.gwtproject.safehtml.shared.annotations.IsTrustedResourceUri;
 import org.gwtproject.safehtml.shared.annotations.SuppressIsTrustedResourceUriCastCheck;
@@ -53,14 +52,14 @@ public class ObjectElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/OptGroupElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/OptGroupElement.java
@@ -21,7 +21,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Group options together in logical subdivisions.
@@ -50,14 +49,14 @@ public class OptGroupElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/OptionElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/OptionElement.java
@@ -21,7 +21,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * A selectable choice.
@@ -49,14 +48,14 @@ public class OptionElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/ParagraphElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/ParagraphElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Paragraphs.
@@ -46,14 +45,14 @@ public class ParagraphElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/ParamElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/ParamElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Parameters fed to the OBJECT element.
@@ -47,14 +46,14 @@ public class ParamElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/PreElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/PreElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Preformatted text.
@@ -46,14 +45,14 @@ public class PreElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/QuoteElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/QuoteElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.gwtproject.safehtml.shared.SafeUri;
 import org.gwtproject.safehtml.shared.annotations.IsSafeUri;
 
@@ -50,14 +49,14 @@ public class QuoteElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/ScriptElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/ScriptElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 import org.gwtproject.safehtml.shared.annotations.IsTrustedResourceUri;
 
 /**
@@ -49,14 +48,14 @@ public class ScriptElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/SelectElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/SelectElement.java
@@ -21,7 +21,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * The select element allows the selection of an option.
@@ -51,14 +50,14 @@ public class SelectElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/SourceElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/SourceElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * The SOURCE element specifies one of potentially multiple source file in a media element.
@@ -47,14 +46,14 @@ public class SourceElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/SpanElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/SpanElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Generic inline container.
@@ -46,14 +45,14 @@ public class SpanElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/StyleElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/StyleElement.java
@@ -21,7 +21,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Style information.
@@ -53,14 +52,14 @@ public class StyleElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/StyleInjector.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/StyleInjector.java
@@ -15,8 +15,7 @@
  */
 package org.gwtproject.dom.client;
 
-import org.gwtproject.core.client.JavaScriptObject;
-import org.gwtproject.core.client.JsArrayString;
+import elemental2.core.JsArray;
 import org.gwtproject.core.client.Scheduler;
 import org.gwtproject.core.client.Scheduler.ScheduledCommand;
 
@@ -29,9 +28,9 @@ public class StyleInjector {
 
   private static HeadElement head;
 
-  private static final JsArrayString toInject = JavaScriptObject.createArray().cast();
-  private static final JsArrayString toInjectAtEnd = JavaScriptObject.createArray().cast();
-  private static final JsArrayString toInjectAtStart = JavaScriptObject.createArray().cast();
+  private static final JsArray<String> toInject = new JsArray<>();
+  private static final JsArray<String> toInjectAtEnd = new JsArray<>();
+  private static final JsArray<String> toInjectAtStart = new JsArray<>();
 
   private static ScheduledCommand flusher =
       new ScheduledCommand() {
@@ -173,11 +172,11 @@ public class StyleInjector {
   }
 
   /** The <code>which</code> parameter is used to support the injectStylesheet API. */
-  private static StyleElement flush(JavaScriptObject which) {
+  private static StyleElement flush(JsArray<String> which) {
     StyleElement toReturn = null;
     StyleElement maybeReturn;
 
-    if (toInjectAtStart.length() != 0) {
+    if (toInjectAtStart.length != 0) {
       String css = toInjectAtStart.join("");
       maybeReturn = injectStyleSheetAtStart(css);
       if (toInjectAtStart == which) {
@@ -186,7 +185,7 @@ public class StyleInjector {
       toInjectAtStart.setLength(0);
     }
 
-    if (toInject.length() != 0) {
+    if (toInject.length != 0) {
       String css = toInject.join("");
       maybeReturn = injectStyleSheet(css);
       if (toInject == which) {
@@ -195,7 +194,7 @@ public class StyleInjector {
       toInject.setLength(0);
     }
 
-    if (toInjectAtEnd.length() != 0) {
+    if (toInjectAtEnd.length != 0) {
       String css = toInjectAtEnd.join("");
       maybeReturn = injectStyleSheetAtEnd(css);
       if (toInjectAtEnd == which) {

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/TableCaptionElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/TableCaptionElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Table caption.
@@ -46,14 +45,14 @@ public class TableCaptionElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/TableCellElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/TableCellElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * The object used to represent the TH and TD elements.
@@ -48,14 +47,14 @@ public class TableCellElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/TableColElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/TableColElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Regroups the COL and COLGROUP elements.
@@ -48,14 +47,14 @@ public class TableColElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/TableElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/TableElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * The create* and delete* methods on the table allow authors to construct and modify tables. [HTML
@@ -50,14 +49,14 @@ public class TableElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/TableRowElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/TableRowElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * A row in a table.
@@ -47,14 +46,14 @@ public class TableRowElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/TableSectionElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/TableSectionElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /** The THEAD, TFOOT, and TBODY elements. */
 @JsType(isNative = true, name = "Object", namespace = JsPackage.GLOBAL)
@@ -53,14 +52,14 @@ public class TableSectionElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/TextAreaElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/TextAreaElement.java
@@ -21,7 +21,6 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Multi-line text field.
@@ -50,14 +49,14 @@ public class TextAreaElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/TitleElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/TitleElement.java
@@ -19,7 +19,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * The document title.
@@ -47,14 +46,14 @@ public class TitleElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }

--- a/gwt-dom/src/main/java/org/gwtproject/dom/client/UListElement.java
+++ b/gwt-dom/src/main/java/org/gwtproject/dom/client/UListElement.java
@@ -18,7 +18,6 @@ package org.gwtproject.dom.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
-import org.gwtproject.core.client.JavaScriptObject;
 
 /**
  * Unordered list.
@@ -46,14 +45,14 @@ public class UListElement extends Element {
   }
 
   /**
-   * Determines whether the given {@link JavaScriptObject} can be cast to this class. A <code>null
+   * Determines whether the given object can be cast to this class. A <code>null
    * </code> object will cause this method to return <code>false</code>.
    *
    * @param o the object to check if it is an instance of this type
    * @return true of the object is an instance of this type, false otherwise
    */
   @JsOverlay
-  public static boolean is(JavaScriptObject o) {
+  public static boolean is(Object o) {
     if (Element.is(o)) {
       return is((Element) o);
     }


### PR DESCRIPTION
JavaScriptObject and JsArray are deprecated, some usages can be just removed:

* some APIs generalized to accept `Object` instead of `JavaScriptObject`
* usages of `JsArray` in local variables/private fields removed